### PR TITLE
History

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -35,13 +35,14 @@ static int ScoreMove(Board &board, Move &move) {
             targetType = Pawn;
         }
 
-        return moveScoreTable[attackerType][targetType] + 10000;
+        return moveScoreTable[attackerType][targetType] + 30000;
     } else {
         if (killerMoves[0][ply] == move) {
-            return 9000;
+            return 20000;
         } else if (killerMoves[1][ply] == move) {
-            return 8000;
+            return 18000;
         } else {
+            // Max 16384
             return historyMoves[board.sideToMove][move.MoveFrom()][move.MoveTo()];
         }
     }
@@ -235,6 +236,9 @@ SearchResults PVS(Board board, int depth, int alpha, int beta) {
             if (!currMove.IsCapture()) {
                 killerMoves[1][ply] = killerMoves[0][ply];
                 killerMoves[0][ply] = currMove;
+
+                historyMoves[board.sideToMove][currMove.MoveFrom()][currMove.MoveTo()] =
+                    std::min(16384, historyMoves[board.sideToMove][currMove.MoveFrom()][currMove.MoveTo()] + depth * depth);
             }
 
             TT.WriteEntry(board.hashKey, depth, score, CutNode, Move());
@@ -244,10 +248,6 @@ SearchResults PVS(Board board, int depth, int alpha, int beta) {
         results.score = std::max(score, results.score);
 
         if (score > alpha) {
-            if (!currMove.IsCapture()) {
-                historyMoves[board.sideToMove][currMove.MoveFrom()][currMove.MoveTo()] += depth * depth;
-            }
-
             nodeType = PV;
             alpha = score;
             results.bestMove = currMove;

--- a/source/search.cpp
+++ b/source/search.cpp
@@ -24,7 +24,7 @@ Stopwatch sw;
 static int ScoreMove(Board &board, Move &move) {
     TTEntry *current = TT.GetRawEntry(board.hashKey);
     if (current->bestMove == move) {
-        return 500000;
+        return 50000;
     }
 
     if (move.IsCapture()) {
@@ -38,9 +38,9 @@ static int ScoreMove(Board &board, Move &move) {
         return moveScoreTable[attackerType][targetType] + 10000;
     } else {
         if (killerMoves[0][ply] == move) {
-            return 490000;
+            return 9000;
         } else if (killerMoves[1][ply] == move) {
-            return 480000;
+            return 8000;
         } else {
             return historyMoves[board.sideToMove][move.MoveFrom()][move.MoveTo()];
         }

--- a/source/search.cpp
+++ b/source/search.cpp
@@ -205,8 +205,10 @@ SearchResults PVS(Board board, int depth, int alpha, int beta) {
 
     // For all moves
     for (int i = 0; i < board.currentMoveIndex; i++) {
+        Move currMove = board.moveList[i];
+
         Board copy = board;
-        copy.MakeMove(copy.moveList[i]);
+        copy.MakeMove(currMove);
 
         // First move (suspected PV node)
         if (!i) {
@@ -230,13 +232,9 @@ SearchResults PVS(Board board, int depth, int alpha, int beta) {
 
         // Fail high (beta cutoff)
         if (score >= beta) {
-            Move currMove = board.moveList[i];
-
             if (!currMove.IsCapture()) {
                 killerMoves[1][ply] = killerMoves[0][ply];
                 killerMoves[0][ply] = currMove;
-
-                historyMoves[board.sideToMove][currMove.MoveFrom()][currMove.MoveTo()] += depth * depth;
             }
 
             TT.WriteEntry(board.hashKey, depth, score, CutNode, Move());
@@ -246,10 +244,14 @@ SearchResults PVS(Board board, int depth, int alpha, int beta) {
         results.score = std::max(score, results.score);
 
         if (score > alpha) {
+            if (!currMove.IsCapture()) {
+                historyMoves[board.sideToMove][currMove.MoveFrom()][currMove.MoveTo()] += depth * depth;
+            }
+
             nodeType = PV;
             alpha = score;
-            results.bestMove = board.moveList[i];
-            pvLine.SetMove(ply, board.moveList[i]);
+            results.bestMove = currMove;
+            pvLine.SetMove(ply, currMove);
         }
     }
 


### PR DESCRIPTION
Elo   | 40.03 +- 13.84 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1508 W: 586 L: 413 D: 509
Penta | [50, 141, 244, 224, 95]
https://rektdie.pythonanywhere.com/test/151/

bench 1146300