### PR TITLE
expanded QS to noisy moves instead of only captures | bench 902872

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -137,23 +137,21 @@ static SearchResults Quiescence(Board board, int alpha, int beta, int ply) {
     SearchResults results;
 
     for (int i = 0; i < board.currentMoveIndex; i++) {
-        if (board.moveList[i].IsCapture()) {
-            Board copy = board;
-            int isLegal = copy.MakeMove(board.moveList[i]);
-            if (!isLegal) continue;
-            int score = -Quiescence(copy, -beta, -alpha, ply + 1).score;
-            positionIndex--;
+        Board copy = board;
+        int isLegal = copy.MakeMove(board.moveList[i]);
+        if (!isLegal) continue;
+        int score = -Quiescence(copy, -beta, -alpha, ply + 1).score;
+        positionIndex--;
 
-            if (score >= beta) {
-                return score;
-            }
+        if (score >= beta) {
+            return score;
+        }
 
-            bestScore = std::max(score, bestScore);
+        bestScore = std::max(score, bestScore);
 
-            if (score > alpha) {
-                alpha = score;
-                results.bestMove = board.moveList[i];
-            }
+        if (score > alpha) {
+            alpha = score;
+            results.bestMove = board.moveList[i];
         }
     }
 


### PR DESCRIPTION
Elo   | 13.36 +- 7.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3930 W: 937 L: 786 D: 2207
Penta | [79, 418, 831, 547, 90]