### PR TITLE
check extension fix | bench 2953196

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -265,7 +265,7 @@ SearchResults PVS(Board board, int depth, int alpha, int beta, int ply) {
 
         int reductions = GetReductions(board, currMove, depth, moveSeen, ply);
 
-        int newDepth = depth + board.InCheck() - 1;
+        int newDepth = depth + copy.InCheck() - 1;
 
         // First move (suspected PV node)
         if (!moveSeen) {


### PR DESCRIPTION
Elo   | 4.68 +- 3.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16486 W: 4430 L: 4208 D: 7848
Penta | [406, 1992, 3312, 2040, 493]