### PR TITLE
allow lmr in checks | bench 2795598

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -253,7 +253,7 @@ SearchResults PVS(Board board, int depth, int alpha, int beta, int ply) {
         // If our static eval is far below alpha, there is only a small chance
         // that a quiet move will help us so we skip them
         int fpMargin = 100 * depth;
-        if (!isPV && ply && !board.InCheck() && currMove.IsQuiet()
+        if (!isPV && ply && currMove.IsQuiet()
             && depth <= 5 && staticEval + fpMargin < alpha && results.score > MATE_SCORE) {
             continue;
         }


### PR DESCRIPTION
Elo   | 4.57 +- 3.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16806 W: 4436 L: 4215 D: 8155
Penta | [420, 1947, 3474, 2116, 446]