### PR TITLE
checking insufficient material draws | bench 2795598

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -117,6 +117,11 @@ static bool IsFifty(Board &board) {
     return (board.halfMoves >= 100);
 }
 
+static bool IsInsuffMat(Board &board) {
+    return (board.occupied.PopCount() <= 3 
+        && !(board.pieces[Pawn] | board.pieces[Queen] | board.pieces[Rook]));
+}
+
 static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int ply) {
     int reduction = 0;
     
@@ -192,7 +197,7 @@ SearchResults PVS(Board board, int depth, int alpha, int beta, int ply) {
     }
 
     pvLine.SetLength(ply);
-    if (ply && (IsThreefold(board) || IsFifty(board))) return 0;
+    if (ply && (IsThreefold(board) || IsFifty(board) || IsInsuffMat(board))) return 0;
 
 
     // if NOT PV node then we try to hit the TTable


### PR DESCRIPTION
Elo   | 4.97 +- 3.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9640 W: 1953 L: 1815 D: 5872
Penta | [51, 900, 2805, 988, 76]