### PR TITLE
passing board by reference in PVS and QS | bench 1857933

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -129,7 +129,7 @@ static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int 
 }
 
 template <searchMode mode>
-static SearchResults Quiescence(Board board, int alpha, int beta, int ply, SearchContext& ctx) {
+static SearchResults Quiescence(Board& board, int alpha, int beta, int ply, SearchContext& ctx) {
     if constexpr (mode != nodesMode)  {
         if constexpr (mode != bench) {
             if (ctx.nodes % 1024 == 0) {
@@ -194,7 +194,7 @@ static SearchResults Quiescence(Board board, int alpha, int beta, int ply, Searc
 }
 
 template <bool isPV, searchMode mode>
-SearchResults PVS(Board board, int depth, int alpha, int beta, int ply, SearchContext& ctx) {
+SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchContext& ctx) {
     if constexpr (mode != bench || mode != nodesMode) {
         if (ctx.nodes % 1024 == 0) {
             if constexpr (mode == normal) {
@@ -477,12 +477,12 @@ SearchResults SearchPosition(Board &board, SearchParams params, SearchContext& c
     return results;
 }
 
-template SearchResults PVS<true, searchMode::bench>(Board, int, int, int, int, SearchContext& ctx);
-template SearchResults PVS<false, searchMode::bench>(Board, int, int, int, int, SearchContext& ctx);
-template SearchResults PVS<true, searchMode::normal>(Board, int, int, int, int, SearchContext& ctx);
-template SearchResults PVS<false, searchMode::normal>(Board, int, int, int, int, SearchContext& ctx);
-template SearchResults PVS<true, searchMode::datagen>(Board, int, int, int, int, SearchContext& ctx);
-template SearchResults PVS<false, searchMode::datagen>(Board, int, int, int, int, SearchContext& ctx);
+template SearchResults PVS<true, searchMode::bench>(Board&, int, int, int, int, SearchContext& ctx);
+template SearchResults PVS<false, searchMode::bench>(Board&, int, int, int, int, SearchContext& ctx);
+template SearchResults PVS<true, searchMode::normal>(Board&, int, int, int, int, SearchContext& ctx);
+template SearchResults PVS<false, searchMode::normal>(Board&, int, int, int, int, SearchContext& ctx);
+template SearchResults PVS<true, searchMode::datagen>(Board&, int, int, int, int, SearchContext& ctx);
+template SearchResults PVS<false, searchMode::datagen>(Board&, int, int, int, int, SearchContext& ctx);
 
 template SearchResults SearchPosition<normal>(Board &board, SearchParams params, SearchContext& ctx);
 template SearchResults SearchPosition<bench>(Board &board, SearchParams params, SearchContext& ctx);

--- a/source/search.h
+++ b/source/search.h
@@ -125,7 +125,7 @@ public:
 };
 
 template <bool isPV, searchMode mode>
-SearchResults PVS(Board board, int depth, int alpha, int beta, int ply, SearchContext& ctx);
+SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchContext& ctx);
 
 template <searchMode mode>
 SearchResults SearchPosition(Board &board, SearchParams params, SearchContext& ctx);


### PR DESCRIPTION
Elo   | 9.17 +- 4.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10038 W: 2755 L: 2490 D: 4793
Penta | [259, 1126, 2034, 1291, 309]
https://rektdie.pythonanywhere.com/test/327/