### PR TITLE
diff history bonus formula | bench 4333527

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -373,10 +373,11 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
                 ctx.killerMoves[1][ply] = ctx.killerMoves[0][ply];
                 ctx.killerMoves[0][ply] = currMove;
 
-                int bonus = depth * depth;
+                int bonus = 300 * depth - 250;
 
                 ctx.history.Update(board.sideToMove, currMove, bonus);
 
+                // Malus
                 for (int moveIndex = 0; moveIndex < seenQuietsCount - 1; moveIndex++) {
                     ctx.history.Update(board.sideToMove, seenQuiets[moveIndex], -bonus);
                 }


### PR DESCRIPTION
Elo   | 55.32 +- 16.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1026 W: 400 L: 238 D: 388
Penta | [20, 85, 195, 139, 74]