### PR TITLE
added PVS SEE pruning | bench 3721183

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -405,6 +405,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
             continue;
         }
 
+
         Board copy = board;
         bool isLegal = copy.MakeMove(currMove);
 
@@ -414,6 +415,13 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
         }
         ctx.positionHistory[copy.positionIndex] = copy.hashKey;
         ctx.nodes++;
+
+        // PVS SEE
+        int SEEThreshold = currMove.IsQuiet() ? -80 * depth : -30 * depth * depth;
+
+        if (ply && depth <= 10 && !SEE(board, currMove, SEEThreshold))
+            continue;
+
 
         int reductions = GetReductions(board, currMove, depth, moveSeen, ply, cutnode, ctx);
 


### PR DESCRIPTION
Elo   | 42.29 +- 13.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1288 W: 454 L: 298 D: 536
Penta | [24, 115, 237, 217, 51]