### PR TITLE
storing currMove to tt when in cutnode | bench 3509444

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -481,7 +481,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
                 }
             }
 
-            ctx->TT.WriteEntry(board.hashKey, depth, score, CutNode, Move());
+            ctx->TT.WriteEntry(board.hashKey, depth, score, CutNode, currMove);
             return score;
         }
 


### PR DESCRIPTION
Elo   | 42.93 +- 13.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1220 W: 430 L: 280 D: 510
Penta | [18, 111, 242, 181, 58]