### PR TITLE
added including to nmp + lowered condition depth by one | bench 2172902

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -367,13 +367,15 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
 
             // Null Move Pruning
             if (!ctx->doingNullMove && staticEval >= beta) {
-                if (depth >= 3 && !board.InPossibleZug()) {
+                if (depth > 1 && !board.InPossibleZug()) {
                     Board copy = board;
                     bool isLegal = copy.MakeMove(Move());
                     // Always legal so we dont check it
+                    
+                    const int reduction = 3 + improving;
     
                     ctx->doingNullMove = true;
-                    int score = -PVS<false, mode>(copy, depth - 3, -beta, -beta + 1, ply + 1, ctx, !cutnode).score;
+                    int score = -PVS<false, mode>(copy, depth - reduction, -beta, -beta + 1, ply + 1, ctx, !cutnode).score;
                     ctx->doingNullMove = false;
     
                     if (ctx->searchStopped) return 0;


### PR DESCRIPTION
Elo   | 21.27 +- 8.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2290 W: 658 L: 518 D: 1114
Penta | [26, 251, 487, 319, 62]