### PR TITLE
added 1 ply conthist to lmr | bench 25271003

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -157,7 +157,12 @@ static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int 
             reduction += 2;
 
         // History LMR
-        int historyReduction = ctx->history[board.sideToMove][move.MoveFrom()][move.MoveTo()] / 8192;
+        int historyReduction = ctx->history[board.sideToMove][move.MoveFrom()][move.MoveTo()];
+
+        if (ply > 0)
+            historyReduction += ctx->conthist.GetOnePly(board, move, ctx, ply);
+
+        historyReduction /= 8192;
         reduction -= historyReduction;
     }
 


### PR DESCRIPTION
Elo   | 5.68 +- 4.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10518 W: 2931 L: 2759 D: 4828
Penta | [156, 1221, 2371, 1317, 194]
https://rektdie.pythonanywhere.com/test/619/