### PR TITLE
preventing rfp when tt hit | bench 10038648

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -368,11 +368,11 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
 
     if constexpr (!isPV) {
         if (ttHit) {
-            if (entry->depth >= depth && 
+            if (entry->depth >= depth &&
                 ((entry->nodeType == PV) ||
                 (entry->nodeType == AllNode && entry->score <= alpha) ||
                 (entry->nodeType == CutNode && entry->score >= beta))) {
-                
+
                 return SearchResults(entry->score, entry->bestMove);
             }
         }
@@ -399,7 +399,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
         if (ply) {
             // Reverse Futility Pruning
             int margin = 100 * (depth - improving);
-            if (staticEval - margin >= beta && depth < 7) {
+            if (!ttHit && staticEval - margin >= beta && depth < 7) {
                 return (beta + (staticEval - beta) / 3);
             }
 


### PR DESCRIPTION
Elo   | 10.53 +- 6.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4920 W: 1381 L: 1232 D: 2307
Penta | [79, 528, 1126, 619, 108]
https://rektdie.pythonanywhere.com/test/648/