### PR TITLE
added 1 ply conthist to fp | bench 8636322

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -460,6 +460,10 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
         // If our static eval is far below alpha, there is only a small chance
         // that a quiet move will help us so we skip them
         int historyScore = ctx->history[board.sideToMove][currMove.MoveFrom()][currMove.MoveTo()];
+        
+        if (ply > 0)
+            historyScore += ctx->conthist.GetOnePly(board, currMove, ctx, ply);
+        
         int fpMargin = 100 * depth + historyScore / 32;
 
         if (!isPV && ply && currMove.IsQuiet()


### PR DESCRIPTION
Elo   | 3.42 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22850 W: 5998 L: 5773 D: 11079
Penta | [327, 2709, 5140, 2910, 339]
https://rektdie.pythonanywhere.com/test/802/