### PR TITLE
tweaked nmp reduction | bench 7750226

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -408,7 +408,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
                     Board copy = board;
                     copy.MakeMove(Move());
 
-                    const int reduction = 3 + improving;
+                    const int reduction = 4 + improving + depth / 3;
 
                     ctx->doingNullMove = true;
                     int score = -PVS<false, mode>(copy, depth - reduction, -beta, -beta + 1, ply + 1, ctx, !cutnode).score;


### PR DESCRIPTION
Elo   | 6.60 +- 4.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8636 W: 2309 L: 2145 D: 4182
Penta | [110, 1008, 1950, 1108, 142]
https://rektdie.pythonanywhere.com/test/820/