### PR TITLE
added 2ply conthist to fp | bench 7251156

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -461,8 +461,12 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
         // that a quiet move will help us so we skip them
         int historyScore = ctx->history[board.sideToMove][currMove.MoveFrom()][currMove.MoveTo()];
         
-        if (ply > 0)
+        if (ply > 0) {
             historyScore += ctx->conthist.GetOnePly(board, currMove, ctx, ply);
+            
+            if (ply > 1)
+                historyScore += ctx->conthist.GetTwoPly(board, currMove, ctx, ply);
+        }
         
         int fpMargin = 100 * depth + historyScore / 32;
 


### PR DESCRIPTION
Elo   | 1.99 +- 1.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 86150 W: 22423 L: 21930 D: 41797
Penta | [1184, 10350, 19565, 10741, 1235]
https://rektdie.pythonanywhere.com/test/809/