### PR TITLE
reduce less if pv node | bench 9411909

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -156,6 +156,9 @@ static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int 
         if (cutnode)
             reduction += 2;
 
+        if constexpr (isPV)
+            reduction--;
+
         // History LMR
         int historyReduction = ctx->history[board.sideToMove][move.MoveFrom()][move.MoveTo()];
 


### PR DESCRIPTION
Elo   | 5.31 +- 3.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11382 W: 2983 L: 2809 D: 5590
Penta | [157, 1342, 2548, 1458, 186]