### PR TITLE
reducing more when not improving | bench 6594120

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -153,7 +153,7 @@ bool IsDraw(Board &board, SearchContext* ctx) {
 }
 
 template <bool isPV>
-static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int ply, bool cutnode, SearchContext* ctx) {
+static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int ply, bool cutnode, bool improving, SearchContext* ctx) {
     int reduction = 0;
 
     // Late Move Reduction
@@ -165,6 +165,9 @@ static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int 
 
         if constexpr (isPV)
             reduction -= lmrIsPV;
+    
+        if (!improving)
+            reduction += lmrImproving;
 
         // History LMR
         int historyReduction = ctx->history[board.sideToMove][move.MoveFrom()][move.MoveTo()];
@@ -541,7 +544,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
         if (ply && depth <= 10 && !SEE(board, currMove, SEEThreshold))
             continue;
 
-        int reductions = GetReductions<isPV>(board, currMove, depth, moveSeen, ply, cutnode, ctx);
+        int reductions = GetReductions<isPV>(board, currMove, depth, moveSeen, ply, cutnode, improving, ctx);
 
         int newDepth = depth + copy.InCheck() - 1 + extension;
 

--- a/source/tunables.h
+++ b/source/tunables.h
@@ -11,6 +11,7 @@
     X_INT(lmrCutnode, 2048, 1024, 3072) \
     X_INT(lmrIsPV, 1024, 512, 2048) \
     X_INT(lmrHistoryDivisor, 8192, 6000, 10000) \
+    X_INT(lmrImproving, 1024, 6000, 10000) \
     X_INT(rfpMargin, 100, 50, 200) \
     X_INT(fpMargin, 100, 50, 200) \
     X_INT(doubleExtMargin, 30, 10, 60) \


### PR DESCRIPTION
Elo   | 4.13 +- 3.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16162 W: 4217 L: 4025 D: 7920
Penta | [202, 1950, 3606, 2100, 223]
https://rektdie.pythonanywhere.com/test/938/