### PR TITLE
Lmp improving

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -463,7 +463,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
         // that are late in the list
         if (currMove.IsQuiet() && notMated) {
 
-            int lmpThreshold = 7 + depth * depth / (2 - improving);
+            int lmpThreshold = 7 + depth * depth * (1 + improving);
 
             if (moveSeen >= lmpThreshold) {
                 continue;


### PR DESCRIPTION
Elo   | 3.57 +- 2.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20146 W: 5110 L: 4903 D: 10133
Penta | [252, 2375, 4615, 2576, 255]
https://rektdie.pythonanywhere.com/test/967/