### PR TITLE
fp less when improving | bench 7573487

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -482,7 +482,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
                 historyScore += ctx->conthist.GetTwoPly(board, currMove, ctx, ply);
         }
         
-        int margin = fpMargin * depth + historyScore / 32;
+        int margin = fpMargin * (depth + improving) + historyScore / 32;
 
         if (!isPV && ply && currMove.IsQuiet()
                 && depth <= 5 && staticEval + margin < alpha && notMated) {


### PR DESCRIPTION
Elo   | 2.49 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 41368 W: 10444 L: 10147 D: 20777
Penta | [545, 4892, 9488, 5239, 520]
https://rektdie.pythonanywhere.com/test/972/