### PR TITLE
lowered LMR depth | bench 6409786

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -157,7 +157,7 @@ static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int 
     int reduction = 0;
 
     // Late Move Reduction
-    if (depth >= 3 && moveSeen >= 2 + (2 * isPV) && !move.IsCapture()) {
+    if (depth >= 2 && moveSeen >= 2 + (2 * isPV) && !move.IsCapture()) {
         reduction = lmrTable[depth][moveSeen] * 1024;
 
         if (cutnode)


### PR DESCRIPTION
Elo   | 2.17 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 59984 W: 15011 L: 14636 D: 30337
Penta | [742, 7198, 13783, 7481, 788]
https://rektdie.pythonanywhere.com/test/978/