### PR TITLE
enabled non pawn corrhist | bench 6547831

### DIFF
--- a/source/search.h
+++ b/source/search.h
@@ -52,7 +52,7 @@ class CorrHist {
 private:
     // indexed by [stm][key]
     MultiArray<int, 2, CORRHIST_SIZE> pawnHist;
-    //MultiArray<int, 2, CORRHIST_SIZE> nonPawnHist;
+    MultiArray<int, 2, CORRHIST_SIZE> nonPawnHist;
 public:
     void Update(Board& board, int depth, int diff, int* entry) {
         const int scaledDiff = diff * CORRHIST_GRAIN;
@@ -64,17 +64,17 @@ public:
 
     void UpdateAll(Board& board, int depth, int diff) {
         Update(board, depth, diff, &pawnHist[board.sideToMove][board.pawnKey % CORRHIST_SIZE]);
-        //Update(board, depth, diff, &nonPawnHist[board.sideToMove][board.nonPawnKey % CORRHIST_SIZE]);
+        Update(board, depth, diff, &nonPawnHist[board.sideToMove][board.nonPawnKey % CORRHIST_SIZE]);
     }
 
     int GetAllHist(Board& board) {
-        return pawnHist[board.sideToMove][board.pawnKey % CORRHIST_SIZE];
-        //    +  nonPawnHist[board.sideToMove][board.nonPawnKey % CORRHIST_SIZE];
+        return pawnHist[board.sideToMove][board.pawnKey % CORRHIST_SIZE]
+            +  nonPawnHist[board.sideToMove][board.nonPawnKey % CORRHIST_SIZE];
     }
 
     void Clear() {
         std::fill(&pawnHist[0][0], &pawnHist[0][0] + sizeof(pawnHist) / sizeof(int), 0);
-        //std::fill(&nonPawnHist[0][0], &nonPawnHist[0][0] + sizeof(nonPawnHist) / sizeof(int), 0);
+        std::fill(&nonPawnHist[0][0], &nonPawnHist[0][0] + sizeof(nonPawnHist) / sizeof(int), 0);
     }
 };
 


### PR DESCRIPTION
Elo   | 1.39 +- 1.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | -0.70 (-2.94, 2.94) [0.00, 5.00]
Games | N: 132830 W: 33147 L: 32616 D: 67067
Penta | [1641, 15917, 30772, 16440, 1645]
https://rektdie.pythonanywhere.com/test/995/