### PR TITLE
added a base to rfp | bench 6836864

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -413,7 +413,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
     if (!board.InCheck() && !ctx->excluded) {
         if (ply) {
             // Reverse Futility Pruning
-            int margin = rfpMargin * (depth - improving);
+            int margin = rfpBase + rfpMargin * (depth - improving);
             if (!ttHit && staticEval - margin >= beta && depth < 7) {
                 return (beta + (staticEval - beta) / 3);
             }

--- a/source/tunables.h
+++ b/source/tunables.h
@@ -12,6 +12,7 @@
     X_INT(lmrIsPV, 1024, 512, 2048) \
     X_INT(lmrHistoryDivisor, 8192, 6000, 10000) \
     X_INT(lmrImproving, 1024, 6000, 10000) \
+    X_INT(rfpBase, 25, 50, 200) \
     X_INT(rfpMargin, 100, 50, 200) \
     X_INT(fpMargin, 100, 50, 200) \
     X_INT(doubleExtMargin, 30, 10, 60) \


### PR DESCRIPTION
Elo   | 2.70 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 34420 W: 8677 L: 8410 D: 17333
Penta | [399, 4175, 7883, 4266, 487]
https://rektdie.pythonanywhere.com/test/1019/