### PR TITLE
added multicut | bench 6813804

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -532,6 +532,10 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
                     }
                 }
             }
+            // Multicut
+            else if (sBeta >= beta) {
+                return sBeta;
+            }
             // Negative extension
             else if (entry.score >= beta) {
                 extension--;


### PR DESCRIPTION
Elo   | 2.61 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 37266 W: 9375 L: 9095 D: 18796
Penta | [428, 4453, 8642, 4631, 479]
https://rektdie.pythonanywhere.com/test/1062/