### PR TITLE
extended conthist in lmr | bench 5829415

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -171,8 +171,12 @@ static int GetReductions(Board &board, Move &move, int depth, int moveSeen, int 
 
         // History LMR
         int historyReduction = ctx->history[board.sideToMove][move.MoveFrom()][move.MoveTo()];
-        if (ply > 0)
+        if (ply > 0) {
             historyReduction += ctx->conthist.GetOnePly(board, move, ctx, ply);
+
+            if (ply > 1)
+                historyReduction += ctx->conthist.GetTwoPly(board, move, ctx, ply);
+        }
 
         reduction /= 1024;
 


### PR DESCRIPTION
Elo   | 3.19 +- 2.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24040 W: 6028 L: 5807 D: 12205
Penta | [276, 2844, 5604, 2975, 321]
https://rektdie.pythonanywhere.com/test/1093/