### PR TITLE
negext on cutnodes | bench 5715860

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -550,6 +550,8 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
             // Negative extension
             else if (entry.score >= beta) {
                 extension--;
+            } else if (cutnode) {
+                extension--;
             }
         }
 


### PR DESCRIPTION
Elo   | 2.94 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 28802 W: 7332 L: 7088 D: 14382
Penta | [362, 3436, 6603, 3596, 404]
https://rektdie.pythonanywhere.com/test/1125/