### PR TITLE
added qs fp | bench 6299890

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -312,6 +312,8 @@ static SearchResults Quiescence(Board& board, int alpha, int beta, int ply, Sear
         alpha = bestScore;
     }
 
+    const int fpScore = bestScore + 100;
+
     MOVEGEN::GenerateMoves<Noisy>(board);
 
     SortMoves(board, ply, ctx);
@@ -319,6 +321,14 @@ static SearchResults Quiescence(Board& board, int alpha, int beta, int ply, Sear
     SearchResults results;
 
     for (int i = 0; i < board.currentMoveIndex; i++) {
+        // QS FP
+        if (!board.InCheck() && board.moveList[i].IsCapture() &&
+            fpScore <= alpha && !SEE(board, board.moveList[i], 1)) {
+
+            bestScore = std::max(bestScore, fpScore);
+            continue;
+        }
+
         Board copy = board;
         int isLegal = copy.MakeMove(board.moveList[i]);
         if (!isLegal) continue;


### PR DESCRIPTION
Elo   | 8.54 +- 5.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6188 W: 1651 L: 1499 D: 3038
Penta | [79, 681, 1431, 815, 88]
https://rektdie.pythonanywhere.com/test/1211/