### PR TITLE
prevent razoring when tt is lower bound | bench 1246472

### DIFF
--- a/source/search.cpp
+++ b/source/search.cpp
@@ -458,7 +458,7 @@ SearchResults PVS(Board& board, int depth, int alpha, int beta, int ply, SearchC
             }
 
             // Razoring
-            if (!isPV && depth <= 3 && staticEval + razoringScalar * depth < alpha) {
+            if (!isPV && depth <= 3 && staticEval + razoringScalar * depth < alpha && entry.nodeType != CutNode) {
                 return Quiescence<isPV, mode>(board, alpha, beta, ply, ctx).score;
             }
 


### PR DESCRIPTION
Elo   | 5.99 +- 3.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7072 W: 1320 L: 1198 D: 4554
Penta | [0, 731, 1958, 841, 6]
https://rektdie.pythonanywhere.com/test/4418/